### PR TITLE
fix: add override=True to load_dotenv across all agent scripts

### DIFF
--- a/agents/s01_agent_loop.py
+++ b/agents/s01_agent_loop.py
@@ -41,7 +41,7 @@ from anthropic import Anthropic
 # ---------------------------------------------------------------------------
 
 # 加载 .env -- 向上查找到 claw0 目录
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 MODEL_ID = os.getenv("MODEL_ID", "claude-sonnet-4-20250514")
 client = Anthropic(

--- a/agents/s02_tool_use.py
+++ b/agents/s02_tool_use.py
@@ -49,7 +49,7 @@ from anthropic import Anthropic
 # 配置
 # ---------------------------------------------------------------------------
 
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 MODEL_ID = os.getenv("MODEL_ID", "claude-sonnet-4-20250514")
 client = Anthropic(

--- a/agents/s03_sessions.py
+++ b/agents/s03_sessions.py
@@ -74,7 +74,7 @@ from dotenv import load_dotenv
 # 配置
 # ---------------------------------------------------------------------------
 
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 BASE_URL = os.getenv("ANTHROPIC_BASE_URL", None)
 MODEL = os.getenv("MODEL_ID", "claude-sonnet-4-20250514")

--- a/agents/s04_multi_channel.py
+++ b/agents/s04_multi_channel.py
@@ -88,7 +88,7 @@ from dotenv import load_dotenv
 # 配置
 # ---------------------------------------------------------------------------
 
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 BASE_URL = os.getenv("ANTHROPIC_BASE_URL", None)
 MODEL = os.getenv("MODEL_ID", "claude-sonnet-4-20250514")

--- a/agents/s07_soul_memory.py
+++ b/agents/s07_soul_memory.py
@@ -86,7 +86,7 @@ from anthropic import Anthropic
 # 配置
 # ---------------------------------------------------------------------------
 
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 MODEL_ID = os.getenv("MODEL_ID", "claude-sonnet-4-20250514")
 client = Anthropic(

--- a/agents/s08_heartbeat.py
+++ b/agents/s08_heartbeat.py
@@ -92,7 +92,7 @@ from anthropic import Anthropic
 # 配置
 # ---------------------------------------------------------------------------
 
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 MODEL_ID = os.getenv("MODEL_ID", "claude-sonnet-4-20250514")
 client = Anthropic(

--- a/agents/s09_cron.py
+++ b/agents/s09_cron.py
@@ -112,7 +112,7 @@ except ImportError:
 # 配置
 # ---------------------------------------------------------------------------
 
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 MODEL_ID = os.getenv("MODEL_ID", "claude-sonnet-4-20250514")
 client = Anthropic(

--- a/agents/s10_delivery.py
+++ b/agents/s10_delivery.py
@@ -79,7 +79,7 @@ from anthropic import Anthropic
 # 配置
 # ---------------------------------------------------------------------------
 
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 MODEL_ID = os.getenv("MODEL_ID", "claude-sonnet-4-20250514")
 client = Anthropic(


### PR DESCRIPTION
Ensure .env variables take precedence over existing environment variables for consistent configuration behavior.