### PR TITLE
doc: fix typo that git clone command using anthropics instead of shareAI-lab

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -73,7 +73,7 @@ s01 --> s02 --> s03 --> s04 --> s05
 
 ```sh
 # 1. クローンしてディレクトリに入る
-git clone https://github.com/anthropics/claw0.git && cd claw0
+git clone https://github.com/shareAI-lab/claw0.git && cd claw0
 
 # 2. 依存関係をインストール
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ s01 --> s02 --> s03 --> s04 --> s05
 
 ```sh
 # 1. Clone and enter
-git clone https://github.com/anthropics/claw0.git && cd claw0
+git clone https://github.com/shareAI-lab/claw0.git && cd claw0
 
 # 2. Install dependencies
 pip install -r requirements.txt

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,7 +73,7 @@ s01 --> s02 --> s03 --> s04 --> s05
 
 ```sh
 # 1. 克隆并进入目录
-git clone https://github.com/anthropics/claw0.git && cd claw0
+git clone https://github.com/shareAI-lab/claw0.git && cd claw0
 
 # 2. 安装依赖
 pip install -r requirements.txt


### PR DESCRIPTION
Fixes a typo in the documentation where the `git clone` command was using the incorrect organization name `anthropics` instead of the correct one `shareAI-lab`.
