### PR TITLE
Fix #7 Add label support to /switch in session examples

### DIFF
--- a/sessions/en/s03_sessions.py
+++ b/sessions/en/s03_sessions.py
@@ -668,19 +668,36 @@ def handle_repl_command(
 
     elif cmd == "/switch":
         if not arg:
-            print_warn("  Usage: /switch <session_id>")
+            print_warn("  Usage: /switch <session_id_or_label>")
             return True, messages
-        target_id = arg.strip()
-        matched = [sid for sid in store._index if sid.startswith(target_id)]
+        target = arg.strip()
+        exact_matches = [
+            {"sid": sid, "label": meta.get("label", "")}
+            for sid, meta in store._index.items()
+            if meta.get("label", "") == target or sid == target
+        ]
+        matched = exact_matches if exact_matches else [
+            {"sid": sid, "label": meta.get("label", "")}
+            for sid, meta in store._index.items()
+            if (
+                meta.get("label", "").startswith(target)
+                or sid.startswith(target)
+            )
+        ]
         if len(matched) == 0:
-            print_warn(f"  Session not found: {target_id}")
+            print_warn(f"  Session not found: {target}")
             return True, messages
         if len(matched) > 1:
-            print_warn(f"  Ambiguous prefix, matches: {', '.join(matched)}")
+            matches_text = [
+                f"{item['label']} ({item['sid']})" if item["label"] else item["sid"]
+                for item in matched
+            ]
+            print_warn(f"  Ambiguous prefix, matches: {', '.join(matches_text)}")
             return True, messages
-        sid = matched[0]
+        sid = matched[0]["sid"]
+        label = matched[0]["label"]
         new_messages = store.load_session(sid)
-        print_session(f"  Switched to session: {sid} ({len(new_messages)} messages)")
+        print_session(f"  Switched to session: {label} {sid} ({len(new_messages)} messages)")
         return True, new_messages
 
     elif cmd == "/context":
@@ -708,7 +725,7 @@ def handle_repl_command(
         print_info("  Commands:")
         print_info("    /new [label]       Create a new session")
         print_info("    /list              List all sessions")
-        print_info("    /switch <id>       Switch to a session (prefix match)")
+        print_info("    /switch <id|label> Switch by label or id prefix")
         print_info("    /context           Show context token usage")
         print_info("    /compact           Manually compact conversation history")
         print_info("    /help              Show this help")

--- a/sessions/en/s03_sessions.py
+++ b/sessions/en/s03_sessions.py
@@ -671,6 +671,7 @@ def handle_repl_command(
             print_warn("  Usage: /switch <session_id_or_label>")
             return True, messages
         target = arg.strip()
+        # Resolution order: exact label/id, then prefix match.
         exact_matches = [
             {"sid": sid, "label": meta.get("label", "")}
             for sid, meta in store._index.items()

--- a/sessions/ja/s03_sessions.py
+++ b/sessions/ja/s03_sessions.py
@@ -685,6 +685,7 @@ def handle_repl_command(
             print_warn("  Usage: /switch <session_id_or_label>")
             return True, messages
         target = arg.strip()
+        # 解決順序: 先に label/id 完全一致、次に前方一致。
         exact_matches = [
             {"sid": sid, "label": meta.get("label", "")}
             for sid, meta in store._index.items()

--- a/sessions/ja/s03_sessions.py
+++ b/sessions/ja/s03_sessions.py
@@ -682,22 +682,37 @@ def handle_repl_command(
 
     elif cmd == "/switch":
         if not arg:
-            print_warn("  Usage: /switch <session_id>")
+            print_warn("  Usage: /switch <session_id_or_label>")
             return True, messages
-        target_id = arg.strip()
-        matched = [
-            sid for sid in store._index if sid.startswith(target_id)
+        target = arg.strip()
+        exact_matches = [
+            {"sid": sid, "label": meta.get("label", "")}
+            for sid, meta in store._index.items()
+            if meta.get("label", "") == target or sid == target
+        ]
+        matched = exact_matches if exact_matches else [
+            {"sid": sid, "label": meta.get("label", "")}
+            for sid, meta in store._index.items()
+            if (
+                meta.get("label", "").startswith(target)
+                or sid.startswith(target)
+            )
         ]
         if len(matched) == 0:
-            print_warn(f"  Session not found: {target_id}")
+            print_warn(f"  Session not found: {target}")
             return True, messages
         if len(matched) > 1:
-            print_warn(f"  Ambiguous prefix, matches: {', '.join(matched)}")
+            matches_text = [
+                f"{item['label']} ({item['sid']})" if item["label"] else item["sid"]
+                for item in matched
+            ]
+            print_warn(f"  Ambiguous prefix, matches: {', '.join(matches_text)}")
             return True, messages
 
-        sid = matched[0]
+        sid = matched[0]["sid"]
+        label = matched[0]["label"]
         new_messages = store.load_session(sid)
-        print_session(f"  Switched to session: {sid} ({len(new_messages)} messages)")
+        print_session(f"  Switched to session: {label} {sid} ({len(new_messages)} messages)")
         return True, new_messages
 
     elif cmd == "/context":
@@ -725,7 +740,7 @@ def handle_repl_command(
         print_info("  Commands:")
         print_info("    /new [label]       Create a new session")
         print_info("    /list              List all sessions")
-        print_info("    /switch <id>       Switch to a session (prefix match)")
+        print_info("    /switch <id|label> Switch by label or id prefix")
         print_info("    /context           Show context token usage")
         print_info("    /compact           Manually compact conversation history")
         print_info("    /help              Show this help")

--- a/sessions/zh/s03_sessions.py
+++ b/sessions/zh/s03_sessions.py
@@ -686,6 +686,7 @@ def handle_repl_command(
             return True, messages
         target = arg.strip()
 
+        # 解析顺序：先精确匹配 label/id，再匹配前缀。
         exact_matches = [
             {"sid": sid, "label": meta.get("label", "")}
             for sid, meta in store._index.items()

--- a/sessions/zh/s03_sessions.py
+++ b/sessions/zh/s03_sessions.py
@@ -682,22 +682,40 @@ def handle_repl_command(
 
     elif cmd == "/switch":
         if not arg:
-            print_warn("  Usage: /switch <session_id>")
+            print_warn("  Usage: /switch <session_id_or_label>")
             return True, messages
-        target_id = arg.strip()
-        matched = [
-            sid for sid in store._index if sid.startswith(target_id)
+        target = arg.strip()
+
+        exact_matches = [
+            {"sid": sid, "label": meta.get("label", "")}
+            for sid, meta in store._index.items()
+            if meta.get("label", "") == target or sid == target
         ]
+
+        matched = exact_matches if exact_matches else [
+            {"sid": sid, "label": meta.get("label", "")}
+            for sid, meta in store._index.items()
+            if (
+                meta.get("label", "").startswith(target)
+                or sid.startswith(target)
+            )
+        ]
+
         if len(matched) == 0:
-            print_warn(f"  Session not found: {target_id}")
+            print_warn(f"  Session not found: {target}")
             return True, messages
         if len(matched) > 1:
-            print_warn(f"  Ambiguous prefix, matches: {', '.join(matched)}")
+            matches_text = [
+                f"{item['label']} ({item['sid']})" if item["label"] else item["sid"]
+                for item in matched
+            ]
+            print_warn(f"  Ambiguous prefix, matches: {', '.join(matches_text)}")
             return True, messages
 
-        sid = matched[0]
+        sid = matched[0]["sid"]
+        label = matched[0]["label"]
         new_messages = store.load_session(sid)
-        print_session(f"  Switched to session: {sid} ({len(new_messages)} messages)")
+        print_session(f"  Switched to session: {label} {sid} ({len(new_messages)} messages)")
         return True, new_messages
 
     elif cmd == "/context":
@@ -725,7 +743,7 @@ def handle_repl_command(
         print_info("  Commands:")
         print_info("    /new [label]       Create a new session")
         print_info("    /list              List all sessions")
-        print_info("    /switch <id>       Switch to a session (prefix match)")
+        print_info("    /switch <id|label> Switch by label or id prefix")
         print_info("    /context           Show context token usage")
         print_info("    /compact           Manually compact conversation history")
         print_info("    /help              Show this help")


### PR DESCRIPTION
This PR adds label support to /switch in the session examples.

  Users can now switch sessions by either session id or label in:

  - sessions/zh/s03_sessions.py
  - sessions/en/s03_sessions.py
  - sessions/ja/s03_sessions.py

  The matching rule is intentionally kept simple:

  1. exact match on session id or label
  2. prefix match on session id or label